### PR TITLE
validate geometry DXF import before importing

### DIFF
--- a/plugin/oiv/bag_pand/oiv_import_file_widget.ui
+++ b/plugin/oiv/bag_pand/oiv_import_file_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>490</width>
+    <width>374</width>
     <height>699</height>
    </rect>
   </property>
@@ -143,7 +143,24 @@ border-color: rgba(255, 255, 255, 0);</string>
       <item>
        <widget class="QLabel" name="label7">
         <property name="text">
-         <string>7. Alle controles zijn goed u kunt importeren.</string>
+         <string>7. Maak eerst een validatie import. Alle ongeldige geometriën en geometriën die &gt;100m vanaf de bouwlaag liggen worden er uitgefilterd.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="validatie_import">
+        <property name="text">
+         <string>Validatie Import</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label8">
+        <property name="text">
+         <string>8. Alle controles zijn goed u kunt importeren.</string>
         </property>
        </widget>
       </item>

--- a/plugin/oiv/helpers/constants.py
+++ b/plugin/oiv/helpers/constants.py
@@ -35,14 +35,14 @@ def bagpand_layername():
     return None
 
 
-OIV_VERSION = '3.3.2'
+OIV_VERSION = '3.3.3'
 
 PLUGIN = {
     "name": "OIV Objecten",
     "toolbartext": "OIV " + OIV_VERSION + " | Actieve bouwlaag: ",
     "compatibleDbVersion": {
         "min": 330,
-        "max": 332
+        "max": 333
     },
     "menulocation": "&OIV Objecten",
     "settingsname": "Configure",

--- a/plugin/oiv/helpers/utils_core.py
+++ b/plugin/oiv/helpers/utils_core.py
@@ -68,12 +68,16 @@ def check_layer_type(layer):
         layerType = "undefined"
     return layerType
 
-def write_layer(layer, childFeature, count=False):
+def write_layer(layer, features, count=False, check=True):
     """write the attributes to layer"""
-    layer.startEditing()
-    checkGeomValidity = childFeature.geometry().isGeosValid()
+    checkGeomValidity = True
+    if not isinstance(features, list):
+        features = [features]
+    if check:
+        checkGeomValidity = features.geometry().isGeosValid()
     if checkGeomValidity:
-        dummy, newFeatures = layer.dataProvider().addFeatures([childFeature])
+        layer.startEditing()
+        dummy, newFeatures = layer.dataProvider().addFeatures(features)
         layer.commitChanges()
         layer.reload()
         layer.triggerRepaint()
@@ -91,13 +95,13 @@ def nearest_neighbor(iface, layer, point):
     parentId = None
     parentFeature = None
     extent = iface.mapCanvas().extent()
-    #veroorzaakt foutmelding als er niets in het kaartvenster staat, daarom in try/except statement
+    # veroorzaakt foutmelding als er niets in het kaartvenster staat, daarom in try/except statement
     index = QC.QgsSpatialIndex(layer.getFeatures(QC.QgsFeatureRequest(extent)))
     try:
         parentId = index.nearestNeighbor(point, 1)[0]
         parentFeature = next(layer.getFeatures(QC.QgsFeatureRequest(parentId)))
         parentId = parentFeature["id"]
-    except: # pylint: disable=bare-except
+    except:  # pylint: disable=bare-except
         pass
     return parentFeature, parentId
 


### PR DESCRIPTION
- split DXF import geometries in valid and invalid.
- Invalid: lines <2 points, ploygon <3 points
- Invalid: distance from bouwlaag centroid to geometry > 100m
- added functionality to interface
resolves #135 resolves #134